### PR TITLE
Prefer embedding sync.Mutex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.rice-box.go
 tmp
+devd
+devd.exe


### PR DESCRIPTION
These patches prefer embedding `sync.Mutex`, instead of using it as a member variable. They also add the `devd[.exe]` binary to `.gitignore`.

All unit tests pass and `go fmt` was ran.