### PR TITLE
Add an exclude flag

### DIFF
--- a/devd.go
+++ b/devd.go
@@ -237,6 +237,11 @@ func main() {
 		Default("false").
 		Bool()
 
+	excludes := kingpin.Flag("exclude", "Glob pattern for files to exclude from livereload.").
+		PlaceHolder("PATTERN").
+		Short('x').
+		Strings()
+
 	routes := kingpin.Arg(
 		"route",
 		`Routes have the following forms:
@@ -246,6 +251,7 @@ func main() {
 			<URL>
 		`,
 	).Required().Strings()
+
 	kingpin.Version(version)
 
 	kingpin.Parse()
@@ -340,7 +346,7 @@ func main() {
 		}
 	}
 	if len(*watch) > 0 {
-		err = WatchPaths(*watch, lr)
+		err = WatchPaths(*watch, *excludes, lr, logger)
 		if err != nil {
 			kingpin.Fatalf("Could not watch path for livereload: %s", err)
 		}

--- a/watch_test.go
+++ b/watch_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/cortesi/devd/termlog"
+)
+
+var filterFilesTests = []struct {
+	pattern  string
+	files    []string
+	expected []string
+}{
+	{
+		"*",
+		[]string{"main.cpp", "main.go", "main.h", "foo.go", "bar.py"},
+		[]string{},
+	},
+	{
+		"*.go",
+		[]string{"main.cpp", "main.go", "main.h", "foo.go", "bar.py"},
+		[]string{"main.cpp", "main.h", "bar.py"},
+	},
+	// Invalid patterns won't match anything. This would trigger a warning at
+	// runtime.
+	{
+		"[[",
+		[]string{"main.cpp", "main.go", "main.h", "foo.go", "bar.py"},
+		[]string{"main.cpp", "main.go", "main.h", "foo.go", "bar.py"},
+	},
+}
+
+func TestFilterFiles(t *testing.T) {
+	logger := termlog.DummyLogger{}
+
+	for i, tt := range filterFilesTests {
+		result := filterFiles("", tt.files, []string{tt.pattern}, &logger)
+		err := false
+
+		if len(result) != len(tt.expected) {
+			err = true
+		} else {
+			for j := range result {
+				if result[j] != tt.expected[j] {
+					err = true
+					break
+				}
+			}
+		}
+
+		if err {
+			t.Errorf("Test %d (pattern %s), expected \"%s\" got \"%s\"", i, tt.pattern, tt.expected, result)
+		}
+	}
+}


### PR DESCRIPTION
The exclude flag (`-x` or `--exclude`) will add a file glob pattern to a
set of excludes. When excludes are specified, paths that are watched
will only trigger live reloads if one of the modified files does not
match the exclude patterns.

This patch fixes #8.