### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ devd -w ./src http://localhost:8080
 
 # Using devd with modd
 
-```modd -p
+```
+modd -p
     -p "go install ./cmd/server"
     -d "server -p 8080"
     -d "devd -L http://localhost:8080"


### PR DESCRIPTION
the bottom half of the readme was showing as a quoted code section