### PR TITLE
Don't continue building if a build fails

### DIFF
--- a/build
+++ b/build
@@ -58,7 +58,7 @@ def build(vers, goos, goarch, name, archive):
     env = os.environ.copy()
     env["GOOS"] = goos
     env["GOARCH"] = goarch
-    subprocess.call(
+    subprocess.check_call(
         [
             "go", "build",
             "-o", os.path.join(dst, "devd"),


### PR DESCRIPTION
When you lack a dependency, the build script fails one time for each arch. Instead, it should quit building if one fails, which is what `check_call` does.