### PR TITLE
Specify python2 in build script

### DIFF
--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import contextlib
 import fnmatch


### PR DESCRIPTION
My build failed initially because I have python 3 as my default python