### PR TITLE
Request no compression from proxied server

### DIFF
--- a/reverseproxy/reverseproxy.go
+++ b/reverseproxy/reverseproxy.go
@@ -73,6 +73,11 @@ func NewSingleHostReverseProxy(target *url.URL, ci inject.CopyInject) *ReversePr
 		if req.Header.Get("X-Forwarded-Host") == "" {
 			req.Header.Set("X-Forwarded-Host", req.Host)
 		}
+
+		// Set "identity"-only content encoding, in order for injector to
+		// work on text response
+		req.Header.Set("Accept-Encoding", "identity")
+
 		req.Host = req.URL.Host
 		if targetQuery == "" || req.URL.RawQuery == "" {
 			req.URL.RawQuery = targetQuery + req.URL.RawQuery

--- a/reverseproxy/reverseproxy_test.go
+++ b/reverseproxy/reverseproxy_test.go
@@ -37,6 +37,12 @@ func TestReverseProxy(t *testing.T) {
 		if g, e := r.Host, "some-name"; g == e {
 			t.Errorf("backend got original Host header %q, expected over-written", g)
 		}
+		if acceptEncoding := r.Header.Get("Accept-Encoding"); acceptEncoding != "identity" {
+			t.Errorf(
+				"backend got unexpected  or no Accept-Encoding header: %q, expected \"identity\"",
+				acceptEncoding,
+			)
+		}
 		w.Header().Set("X-Foo", "bar")
 		http.SetCookie(w, &http.Cookie{Name: "flavor", Value: "chocolateChip"})
 		w.WriteHeader(backendStatus)


### PR DESCRIPTION
When injecting text in the proxied response, eg. for
live-reload, devd requires an uncompressed text response
to modify.

Send request header `Accept-Encoding: identity`.