### PR TITLE
Do not test vendor packages in modd.conf

### DIFF
--- a/modd.conf
+++ b/modd.conf
@@ -1,5 +1,5 @@
 
-**/*.go {
+**/*.go !vendor/ {
     prep: go test @dirmods
 }
 


### PR DESCRIPTION
When running `$ modd` `go test @dirmods` fails with:

```
17:10:03: prep: go test "./slowdown" "./vendor/github.com/GeertJohan/go.incremental/example" "./vendor/github.com/fatih/color/vendor/github.com/mattn/go-isatty" "./vendor/github.com/gorilla/websocket" "./vendor/github.com/rjeczalik/notify" "./vendor/golang.org/x/net/context/ctxhttp" "./httpctx" "./fileserver" "./inject" "./reverseproxy" "./timer" "./vendor/github.com/GeertJohan/go.rice/embedded" "./vendor/github.com/fatih/color/vendor/github.com/mattn/go-colorable" "./vendor/github.com/gorilla/websocket/examples/filewatch" "./cmd/devd" "./vendor/golang.org/x/net/context" "./vendor/github.com/jessevdk/go-flags/examples" "./vendor/github.com/gorilla/websocket/examples/command" "./vendor/github.com/gorilla/websocket/examples/autobahn" "./vendor/github.com/GeertJohan/go.incremental/gen" "./vendor/github.com/GeertJohan/go.rice/example" "./vendor/github.com/daaku/go.zipexe" "./ricetemp" "./vendor/github.com/GeertJohan/go.rice" "./vendor/github.com/akavel/rsrc/coff" "./vendor/github.com/goji/httpauth" "./vendor/github.com/gorilla/websocket/examples/echo" "./vendor/github.com/jessevdk/go-flags" "./vendor/github.com/juju/ratelimit" "./." "./vendor/github.com/GeertJohan/go.rice/rice" "./vendor/github.com/davecgh/go-spew/spew" "./vendor/github.com/dustin/go-humanize" "./vendor/github.com/fatih/color" "./vendor/github.com/gorilla/websocket/examples/chat" "./vendor/github.com/mattn/go-colorable" "./vendor/golang.org/x/crypto/ssh/terminal" "./vendor/github.com/GeertJohan/go.incremental" "./vendor/github.com/akavel/rsrc/binutil" "./vendor/github.com/bmatcuk/doublestar" "./vendor/github.com/kardianos/osext" "./livereload" "./vendor/github.com/mattn/go-isatty"
can't load package: package github.com/cortesi/devd/vendor/github.com/gorilla/websocket/examples/echo: no buildable Go source files in /home/thomas/src/github.com/cortesi/devd/vendor/github.com/gorilla/websocket/examples/echo
```

Exclude `./vendor/` from `@dirmods`.