### PR TITLE
Use modd watch mod filter result to apply include/exclude

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -22,9 +22,12 @@ func (r Route) Watch(ch chan []string, excludePatterns []string, log termlog.Log
 		}
 		go func() {
 			for mod := range modchan {
-				mod.Filter([]string{"*"}, excludePatterns)
-				if !mod.Empty() {
-					ch <- mod.All()
+				filteredMod, err := mod.Filter([]string{"**/*"}, excludePatterns)
+				if err != nil {
+					log.Shout("Error filtering watches: %s", err)
+				}
+				if !filteredMod.Empty() {
+					ch <- filteredMod.All()
 				}
 			}
 		}()
@@ -43,9 +46,12 @@ func WatchPaths(paths, excludePatterns []string, reloader livereload.Reloader, l
 		}
 		go func() {
 			for mod := range modchan {
-				mod.Filter([]string{"*"}, excludePatterns)
-				if !mod.Empty() {
-					ch <- mod.All()
+				filteredMod, err := mod.Filter([]string{"**/*"}, excludePatterns)
+				if err != nil {
+					log.Shout("Error filtering watches: %s", err)
+				}
+				if !filteredMod.Empty() {
+					ch <- filteredMod.All()
 				}
 			}
 		}()


### PR DESCRIPTION
I had issues with the `-x` option not being respected. As far as I can tell, `watch.go` should use the result of `mod.Filter`, but i looks like it expects `mod` to be mutated.

Good call on making `mod.Filter` immutable, anyway