### PR TITLE
Improve route visibility and failure handling

### DIFF
--- a/cmd/devd/devd.go
+++ b/cmd/devd/devd.go
@@ -227,6 +227,10 @@ func main() {
 		logger.TimeFmt = ""
 	}
 
+	for _, i := range(dd.Routes) {
+		logger.Say("Route %s -> %s", i.MuxMatch(), i.Endpoint.String())
+	}
+
 	if *tls {
 		home, err := homedir.Dir()
 		if err != nil {

--- a/route.go
+++ b/route.go
@@ -17,9 +17,27 @@ import (
 
 const defaultDomain = "devd.io"
 
-func isURL(s string) bool {
-	return strings.HasPrefix(s, "http://") ||
-		strings.HasPrefix(s, "https://")
+func checkURL(s string) (isURL bool, err error) {
+	var parsed *url.URL
+
+	parsed, err = url.Parse(s)
+	if err != nil {
+		return
+	}
+
+	switch {
+	case parsed.Scheme=="": // No scheme means local file system
+		isURL = false
+	case parsed.Scheme=="http", parsed.Scheme=="https":
+		isURL = true
+	case parsed.Scheme=="ws":
+		err = errors.New(fmt.Sprintf("Websocket protocol not supported: %s", s))
+	default:
+		// A route of "localhost:1234/abc" without the "http" or "https" triggers this case.
+		// Unfortunately a route of "localhost/abc" just looks like a file and is not caught here.
+		err = errors.New(fmt.Sprintf("Unknown scheme '%s': did you mean http or https?: %s", parsed.Scheme, s))
+	}
+	return
 }
 
 // Endpoint is the destination of a Route - either on the filesystem or
@@ -51,7 +69,7 @@ func newForwardEndpoint(path string) (*forwardEndpoint, error) {
 }
 
 func (ep forwardEndpoint) String() string {
-	return ep.String()
+	return "forward to "+ep.Scheme +"://"+ep.Host+ep.Path
 }
 
 // An enpoint that serves a filesystem location
@@ -71,7 +89,7 @@ func (ep filesystemEndpoint) Handler(templates *template.Template, ci inject.Cop
 }
 
 func (ep filesystemEndpoint) String() string {
-	return string(ep)
+	return "reads files from "+string(ep)
 }
 
 // Route is a mapping from a (host, path) tuple to an endpoint.
@@ -109,7 +127,15 @@ func newRoute(s string) (*Route, error) {
 	}
 	var ep endpoint
 	var err error
-	if isURL(value) {
+	var isURL bool
+
+	isURL, err = checkURL(value)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if isURL {
 		ep, err = newForwardEndpoint(value)
 	} else {
 		ep, err = newFilesystemEndpoint(value)

--- a/route_test.go
+++ b/route_test.go
@@ -64,6 +64,21 @@ var newSpecTests = []struct {
 		&Route{"one.devd.io", "/", tForwardEndpoint("http://three")},
 		"",
 	},
+	{
+		"one=localhost:1234",
+		nil,
+		"Unknown scheme 'localhost': did you mean http or https?: localhost:1234",
+	},
+	{
+		"one=localhost:1234/abc",
+		nil,
+		"Unknown scheme 'localhost': did you mean http or https?: localhost:1234/abc",
+	},
+	{
+		"one=ws://three",
+		nil,
+		"Websocket protocol not supported: ws://three",
+	},
 }
 
 func TestParseSpec(t *testing.T) {


### PR DESCRIPTION
Hi Aldo,

I had some difficulties with devd (which I love!) last week and thought I'd try to save others from similar problems.

The errors with devd were my own. In both cases I was specifying routes that appeared to work but were not being interpeted how I expected.

1. Route "ws://localhost:1234/ws". I expected this to work as a websocket forward, but devd interprets it as local file system root.
2. Route "localhost:2345/wherever". I expected this to route using HTTP to that server but because I forgot the "http://" it was also treated as a local file system root.


In the first case, because devd doesn't support websockets yet, I figured it's best to explicitly say this at startup, saving people the trouble of debugging. Startup will fail with an error like this now:

    Websocket protocol not supported

In the second case, the proposed patch identifies the missing scheme and warns the user:

    Unknown scheme 'localhost': did you mean http or https?: localhost:1234/abc

In all cases, to avoid ambiguities, I added debug-level logging of the routes at startup:

    13:21:55: Route /api/ -> forward to http://localhost:8080/api
    13:21:55: Route / -> reads files from public/

This last point meant changing the default ``String()`` for the endpoints, which may be something to avoid - not sure.

Thanks for considering!
A