### PR TITLE
Add a shortcut for proxying to localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,12 @@ Similarly, a simple reverse proxy can be started like this:
 devd http://localhost:8888
 ```
 
+There is also a shortcut for reverse proxying to localhost:
+
+```
+devd :8888
+
+```
 
 ### Serving default content for files not found
 

--- a/route_test.go
+++ b/route_test.go
@@ -79,6 +79,11 @@ var newSpecTests = []struct {
 		nil,
 		"Websocket protocol not supported: ws://three",
 	},
+	{
+		"one=:1234",
+		&Route{"one.devd.io", "/", tForwardEndpoint("http://localhost:1234")},
+		"",
+	},
 }
 
 func TestParseSpec(t *testing.T) {

--- a/routespec/routespec.go
+++ b/routespec/routespec.go
@@ -70,6 +70,9 @@ func ParseRouteSpec(s string) (*RouteSpec, error) {
 			path = "/" + seq[1]
 		}
 	}
+	if value[0] == ':' {
+		value = "http://localhost" + value
+	}
 	isURL, err := checkURL(value)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Adds a shortcut so that the any route value starting with `:` is transformed into the corresponding port on localhost(Inspired by [httpie](https://github.com/jkbrzt/httpie)). So `:3141` becomes `http://localhost:3141`. I know this could conflict with serving directories that start with a `:`, but that seems rare enough the it would be ok to force users to use a `./` when they need to do that.