### PR TITLE
Fix typo in 2nd "X-Forwarded-Proto" mention.

### DIFF
--- a/reverseproxy/reverseproxy.go
+++ b/reverseproxy/reverseproxy.go
@@ -78,7 +78,7 @@ func NewSingleHostReverseProxy(target *url.URL, ci inject.CopyInject) *ReversePr
 			req.Header.Set("X-Forwarded-Host", req.Host)
 		}
 		if req.Header.Get("X-Forwarded-Proto") == "" {
-			req.Header.Set("X-Forwarded-Prot", req.URL.Scheme)
+			req.Header.Set("X-Forwarded-Proto", req.URL.Scheme)
 		}
 
 		// Set "identity"-only content encoding, in order for injector to


### PR DESCRIPTION
BTW - value seems to have problems, too. Just received "http" from a `devd -s` instance.
Can’t approach that, though, since this is my first character of Go.