### PR TITLE
Fixes setting of X-Forwarded-For-Proto

### DIFF
--- a/cmd/devd/devd.go
+++ b/cmd/devd/devd.go
@@ -187,11 +187,19 @@ func main() {
 		hdrs.Set("Access-Control-Allow-Origin", "*")
 	}
 
+	var servingScheme string
+	if *tls {
+		servingScheme = "https"
+	} else {
+		servingScheme = "http"
+	}
+
 	dd := devd.Devd{
 		// Shaping
 		Latency:  *latency,
 		DownKbps: *downKbps,
 		UpKbps:   *upKbps,
+		ServingScheme: servingScheme,
 
 		AddHeaders: &hdrs,
 

--- a/reverseproxy/reverseproxy.go
+++ b/reverseproxy/reverseproxy.go
@@ -71,7 +71,6 @@ func singleJoiningSlash(a, b string) string {
 func NewSingleHostReverseProxy(target *url.URL, ci inject.CopyInject) *ReverseProxy {
 	targetQuery := target.RawQuery
 	director := func(req *http.Request) {
-		req.URL.Scheme = target.Scheme
 		req.URL.Host = target.Host
 		req.URL.Path = singleJoiningSlash(target.Path, req.URL.Path)
 		if req.Header.Get("X-Forwarded-Host") == "" {
@@ -80,6 +79,7 @@ func NewSingleHostReverseProxy(target *url.URL, ci inject.CopyInject) *ReversePr
 		if req.Header.Get("X-Forwarded-Proto") == "" {
 			req.Header.Set("X-Forwarded-Proto", req.URL.Scheme)
 		}
+		req.URL.Scheme = target.Scheme
 
 		// Set "identity"-only content encoding, in order for injector to
 		// work on text response

--- a/server.go
+++ b/server.go
@@ -139,6 +139,7 @@ type Devd struct {
 	Latency  int
 	DownKbps uint
 	UpKbps   uint
+	ServingScheme string
 
 	// Add headers
 	AddHeaders *http.Header
@@ -163,6 +164,7 @@ type Devd struct {
 // logging, latency, and so forth.
 func (dd *Devd) WrapHandler(log termlog.TermLog, next httpctx.Handler) http.Handler {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.URL.Scheme = dd.ServingScheme
 		revertOriginalHost(r)
 		timr := timer.Timer{}
 		sublog := log.Group()
@@ -177,7 +179,7 @@ func (dd *Devd) WrapHandler(log termlog.TermLog, next httpctx.Handler) http.Hand
 		timr.RequestHeaders()
 		time.Sleep(time.Millisecond * time.Duration(dd.Latency))
 
-		dpath := r.URL.String()
+		dpath := r.RequestURI
 		if !strings.HasPrefix(dpath, "/") {
 			dpath = "/" + dpath
 		}


### PR DESCRIPTION
The downstream request 'X-Forwarded-For' headers should be set
to whatever the proxy is serving. Also do not overwrite or limit the ability to proxy to any schema, independent of what the proxy in serving.

Given the following setup: `sudo devd -p 443 --tls http://localhost:8000`, devd should accept **https** connections and proxy to **http**://localhost, while setting the `X-Forwarded-Proto` to **https**. In its current implementation however the header is set to whatever schema the downstream server (a.k.a. target) has.


Also fixes a minor logging issue, that only showed up now, as `request.URL` includes the scheme, which was simply not set before. Using the URI instead.