### PR TITLE
Improve CORS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+* Improves CORS support. Allows connections with credentials that were
+  previously refused. See
+  <https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSNotSupportingCredentials>
+
 # v0.9: 21 January 2019
 
 * Fix live reload issues on Linux (Delyan Angelov)

--- a/cmd/devd/devd.go
+++ b/cmd/devd/devd.go
@@ -132,7 +132,7 @@ func main() {
 		Short('w').
 		Strings()
 
-	cors := kingpin.Flag("crossdomain", "Set the CORS header Access-Control-Allowed: *").
+	cors := kingpin.Flag("crossdomain", "Set the CORS headers to allow everything (origin, credentials, headers, methods)").
 		Short('X').
 		Default("false").
 		Bool()
@@ -184,7 +184,7 @@ func main() {
 
 	hdrs := make(http.Header)
 	if *cors {
-		hdrs.Set("Access-Control-Allow-Origin", "*")
+		hdrs.Set("Access-Control-Allow-Credentials", "true")
 	}
 
 	var servingScheme string
@@ -196,9 +196,9 @@ func main() {
 
 	dd := devd.Devd{
 		// Shaping
-		Latency:  *latency,
-		DownKbps: *downKbps,
-		UpKbps:   *upKbps,
+		Latency:       *latency,
+		DownKbps:      *downKbps,
+		UpKbps:        *upKbps,
 		ServingScheme: servingScheme,
 
 		AddHeaders: &hdrs,
@@ -208,6 +208,8 @@ func main() {
 		Livereload:       *livereloadNaked,
 		WatchPaths:       *watch,
 		Excludes:         *excludes,
+
+		Cors: *cors,
 
 		Credentials: creds,
 	}

--- a/server.go
+++ b/server.go
@@ -151,6 +151,9 @@ type Devd struct {
 	WatchPaths []string
 	Excludes   []string
 
+	// Add Access-Control-Allow-Origin header
+	Cors bool
+
 	// Logging
 	IgnoreLogs []*regexp.Regexp
 
@@ -192,6 +195,21 @@ func (dd *Devd) WrapHandler(log termlog.TermLog, next httpctx.Handler) http.Hand
 				for _, v := range vals {
 					w.Header().Set(h, v)
 				}
+			}
+		}
+		if dd.Cors {
+			origin := r.Header.Get("Origin")
+			if origin == "" {
+				origin = "*"
+			}
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			requestHeaders := r.Header.Get("Access-Control-Request-Headers")
+			if requestHeaders != "" {
+				w.Header().Set("Access-Control-Allow-Headers", requestHeaders)
+			}
+			requestMethod := r.Header.Get("Access-Control-Request-Method")
+			if requestMethod != "" {
+				w.Header().Set("Access-Control-Allow-Methods", requestMethod)
 			}
 		}
 		flusher, _ := w.(http.Flusher)


### PR DESCRIPTION
In particular allow request with credentials which are not allowed when only `Access-Control-Allow-Origin: *` is specified. Custom response headers must be crafted for each request depending on the Origin request header.

Also, enable preflight responses to Access-Control-Request-Headers.