### PR TITLE
Fix failing TestServeFileWithContentEncoding

### DIFF
--- a/fileserver/fileserver_test.go
+++ b/fileserver/fileserver_test.go
@@ -394,6 +394,7 @@ func TestServeFileWithContentEncoding(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Encoding", "foo")
 		ServeFile(w, r, "testdata/file")
+		w.(http.Flusher).Flush()
 	}))
 	defer ts.Close()
 	resp, err := http.Get(ts.URL)


### PR DESCRIPTION
Synced with golang std http fs_test.go
https://github.com/golang/go/blob/456a90aa1618a6c3aa49ecba46969128e2bfa26f/src/net/http/fs_test.go#L607

See upstream comment why this is needed.

We should probably rebase devd fileserver.* on latest golang fs.*