### PR TITLE
Replace devd.io with localhost for local routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,13 +144,13 @@ The [route specification syntax](#routes) is compact but powerful enough to cate
 
 ### Light-weight virtual hosting
 
-Devd uses a dedicated domain - **devd.io** - to do simple virtual hosting. This
+Devd uses a dedicated domain - **localhost** - to do simple virtual hosting. This
 domain and all its subdomains resolve to 127.0.0.1, which we use to set up
 virtual hosting without any changes to */etc/hosts* or other local
 configuration. Route specifications that don't start with a leading **/** are
-taken to be subdomains of **devd.io**. So, the following command serves a
-static site from devd.io, and reverse proxies a locally running app on
-api.devd.io:
+taken to be subdomains of **localhost**. So, the following command serves a
+static site from localhost, and reverse proxies a locally running app on
+api.localhost:
 
 <pre class="terminal">
 devd ./static api=http://localhost:8888
@@ -185,17 +185,17 @@ Here's a route that serves the directory *./static* under */assets* on the serve
 /assets/=./static
 ```
 
-To use a **devd.io** subdomain (which will resolve to 127.0.0.1), just add it
+To use a **localhost** subdomain (which will resolve to 127.0.0.1), just add it
 to the the front of the root specification. We recognize subdomains by the fact
 that they don't start with a leading **/**. So, this route serves the
-**/static** directory under **static.devd.io/assets**:
+**/static** directory under **static.localhost/assets**:
 
 ```
 static/assets=./static
 ```
 
 Reverse proxy specifications are similar, but the endpoint specification is a
-URL. The following serves a local URL from the root **app.devd.io/login**:
+URL. The following serves a local URL from the root **app.localhost/login**:
 
 ```
 app/login=http://localhost:8888
@@ -203,7 +203,7 @@ app/login=http://localhost:8888
 
 If the **root** specification is omitted, it is assumed to be "/", i.e. a
 pattern matching all paths. So, a simple directory specification serves the
-directory tree directly under **devd.io**:
+directory tree directly under **localhost**:
 
 ```
 devd ./static

--- a/certgen.go
+++ b/certgen.go
@@ -39,8 +39,8 @@ func GenerateCert(dst string) error {
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
 	}
-	template.DNSNames = append(template.DNSNames, "devd.io")
-	template.DNSNames = append(template.DNSNames, "*.devd.io")
+	template.DNSNames = append(template.DNSNames, "localhost")
+	template.DNSNames = append(template.DNSNames, "*.localhost")
 
 	derBytes, err := x509.CreateCertificate(
 		rand.Reader,

--- a/route_test.go
+++ b/route_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/GeertJohan/go.rice"
+	rice "github.com/GeertJohan/go.rice"
 	"github.com/cortesi/devd/inject"
 	"github.com/cortesi/devd/ricetemp"
 )
@@ -51,17 +51,17 @@ var newSpecTests = []struct {
 	{"one=", nil, "invalid spec"},
 	{
 		"one/two=three",
-		&Route{"one.devd.io", "/two", tFilesystemEndpoint("three")},
+		&Route{"one.localhost", "/two", tFilesystemEndpoint("three")},
 		"",
 	},
 	{
 		"one=three",
-		&Route{"one.devd.io", "/", tFilesystemEndpoint("three")},
+		&Route{"one.localhost", "/", tFilesystemEndpoint("three")},
 		"",
 	},
 	{
 		"one=http://three",
-		&Route{"one.devd.io", "/", tForwardEndpoint("http://three")},
+		&Route{"one.localhost", "/", tForwardEndpoint("http://three")},
 		"",
 	},
 	{
@@ -81,7 +81,7 @@ var newSpecTests = []struct {
 	},
 	{
 		"one=:1234",
-		&Route{"one.devd.io", "/", tForwardEndpoint("http://localhost:1234")},
+		&Route{"one.localhost", "/", tForwardEndpoint("http://localhost:1234")},
 		"",
 	},
 }

--- a/routespec/routespec.go
+++ b/routespec/routespec.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-const defaultDomain = "devd.io"
+const defaultDomain = "localhost"
 
 func checkURL(s string) (isURL bool, err error) {
 	var parsed *url.URL

--- a/scripts/mkbrew
+++ b/scripts/mkbrew
@@ -45,7 +45,7 @@ class Devd < Formula
       Process.wait(io.pid)
     end
 
-    assert_match "Listening on http://devd.io", io.read
+    assert_match "Listening on http://localhost", io.read
   end
 end
 """

--- a/server.go
+++ b/server.go
@@ -76,7 +76,8 @@ func revertOriginalHost(r *http.Request) {
 }
 
 // We can remove the mangling once this is fixed:
-// 		https://github.com/golang/go/issues/10463
+//
+//	https://github.com/golang/go/issues/10463
 func hostPortStrip(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		host, _, err := net.SplitHostPort(r.Host)
@@ -105,7 +106,7 @@ func formatURL(tls bool, httpIP string, port int) string {
 	}
 	host := httpIP
 	if httpIP == "0.0.0.0" || httpIP == "127.0.0.1" {
-		host = "devd.io"
+		host = "localhost"
 	}
 	if port == 443 && tls {
 		return fmt.Sprintf("https://%s", host)

--- a/server_test.go
+++ b/server_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/GeertJohan/go.rice"
+	rice "github.com/GeertJohan/go.rice"
 	"github.com/cortesi/devd/inject"
 	"github.com/cortesi/devd/ricetemp"
 	"github.com/cortesi/termlog"
@@ -16,11 +16,11 @@ var formatURLTests = []struct {
 	port   int
 	output string
 }{
-	{true, "127.0.0.1", 8000, "https://devd.io:8000"},
-	{false, "127.0.0.1", 8000, "http://devd.io:8000"},
-	{false, "127.0.0.1", 80, "http://devd.io"},
-	{true, "127.0.0.1", 443, "https://devd.io"},
-	{false, "127.0.0.1", 443, "http://devd.io:443"},
+	{true, "127.0.0.1", 8000, "https://localhost:8000"},
+	{false, "127.0.0.1", 8000, "http://localhost:8000"},
+	{false, "127.0.0.1", 80, "http://localhost"},
+	{true, "127.0.0.1", 443, "https://localhost"},
+	{false, "127.0.0.1", 443, "http://localhost:443"},
 }
 
 func TestFormatURL(t *testing.T) {


### PR DESCRIPTION
Fixes #128

**Problem:**
The default domain `devd.io` no longer resolves to a local address (`127.0.0.1`).

**Solution:**
Replaced `devd.io` with `localhost` (and `*.localhost`) as the default domain for virtual hosting. According to RFC 6761, `*.localhost` is universally recognized and guaranteed to resolve to the loopback address locally in all operating systems and modern browsers, removing the dependency on external DNS.

**Changes:**
- Changed `template.DNSNames` from `devd.io` to `localhost` in `certgen.go`
- Updated default domain constants in `routespec.go`
- Updated routing fallback logic in `server.go`
- Updated test cases in `route_test.go` and `server_test.go`
- Updated `README.md` to reflect the new `localhost` behavior